### PR TITLE
added some documentation, regarding the routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ And finally, generate your configuration file:
 ### 1. Setup two routes
 ```ruby
   get 'my_click_page' => 'tradetracker#index'
-  get 'my_conversion_page' => 'tradetracker#conversion'
+  get 'my_conversion_page' => 'tradetracker#conversion', as: :tradetracker_conversion
 ```
+Name the second route "tradetracker_conversion" (see example above), as it is used by the gem to lookup the path to the conversion pixel.
 ### 2. Create a basic controller (or map to your own)
 ```ruby
 class TradetrackerController < ApplicationController


### PR DESCRIPTION
Hi guys,

while setting up the gem, I noticed that the path to the conversion pixel is looked up by a named route. In the documentation however, this is not specified.

Thanks!

Stijn
